### PR TITLE
Add basic support for RETURNING syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ Select(bar).From(foo).LeftOuterJoin(quux).
 			On(porg.IsEq(bar)).String(d)
 ```
 
+Returning From Insert
+---------------------
+
+(This is Postgres only feature)
+
+You can specify a column from an INSERT to return back to the app:
+
+```go
+// Renders `INSERT INTO foo (bar) VALUES ($1) RETURNING id` on Postgres
+InsertInto(foo).SetString(bar, "quux").Returning(id).String(d)
+```
+
+`Returning()` returns a fetchable row that you can bind from:
+
+```go
+var id int
+row, _ := InsertInto(foo).SetString(bar, "quux").Returning(id).Fetch(d, db)
+row.Scan(&id)
+```
 
 Code Generation
 ---------------

--- a/sqlc/insert.go
+++ b/sqlc/insert.go
@@ -1,0 +1,37 @@
+package sqlc
+
+import (
+	"bytes"
+	"database/sql"
+)
+
+type insert struct {
+	table     TableLike
+	bindings  []TableFieldBinding
+	returning TableField
+}
+
+func InsertInto(t TableLike) InsertSetStep {
+	return &insert{table: t}
+}
+
+func (i *insert) Exec(d Dialect, db *sql.DB) (sql.Result, error) {
+	return exec(d, i, db)
+}
+
+func (i *insert) Returning(f TableField) InsertResultStep {
+	i.returning = f
+	return i
+}
+
+func (i *insert) Fetch(d Dialect, db *sql.DB) (*sql.Row, error) {
+	var buf bytes.Buffer
+	args := i.Render(d, &buf)
+	return db.QueryRow(buf.String(), args...), nil
+}
+
+func (i *insert) set(f TableField, v interface{}) InsertSetMoreStep {
+	binding := TableFieldBinding{Field: f, Value: v}
+	i.bindings = append(i.bindings, binding)
+	return i
+}

--- a/sqlc/render.go
+++ b/sqlc/render.go
@@ -71,6 +71,11 @@ func (i *insert) Render(d Dialect, w io.Writer) (placeholders []interface{}) {
 	fmt.Fprint(w, placeHolderClause)
 	fmt.Fprint(w, ")")
 
+	if i.returning != nil {
+		fmt.Fprint(w, " RETURNING ")
+		fmt.Fprint(w, i.returning.Name())
+	}
+
 	return values
 }
 

--- a/sqlc/sqlc_test.go
+++ b/sqlc/sqlc_test.go
@@ -147,6 +147,10 @@ var rendered = []struct {
 		"INSERT INTO foo (bar) VALUES (?)",
 	},
 	{
+		InsertInto(quux).SetString(col, "col").Returning(id),
+		"INSERT INTO quux (col) VALUES (?) RETURNING id",
+	},
+	{
 		Update(foo).SetString(bar, "quux").Where(baz.Eq("gorp")),
 		"UPDATE foo SET bar = ? WHERE foo.baz = ?",
 	},

--- a/test/db/postgres/002_returning_syntax.sql
+++ b/test/db/postgres/002_returning_syntax.sql
@@ -1,0 +1,5 @@
+CREATE TABLE key_value 
+(
+    id SERIAL PRIMARY KEY,
+    value TEXT
+);

--- a/test/postgres_test.go
+++ b/test/postgres_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	_ "github.com/lib/pq"
 	"github.com/relops/sqlc/sqlc"
+	. "github.com/relops/sqlc/test/generated/postgres"
 	"github.com/relops/sqlc/test/generic"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -22,9 +23,39 @@ func TestPostgres(t *testing.T) {
 
 	deletePostgres(t, db)
 	generic.RunCallRecordGroupTests(t, sqlc.Postgres, db)
+
+	// POSTGRES specific integration tests
+
+	deletePostgres(t, db)
+	testReturning(t, db)
 }
 
 func deletePostgres(t *testing.T, db *sql.DB) {
 	_, err := db.Exec("TRUNCATE call_records;")
+	_, err = db.Exec("TRUNCATE key_value;")
 	assert.NoError(t, err)
+}
+
+// POSTGRES specific RETURNING syntax
+func testReturning(t *testing.T, db *sql.DB) {
+
+	d := sqlc.Postgres
+
+	var returnedId, selectedId int
+
+	row, err := sqlc.InsertInto(KEY_VALUE).SetString(KEY_VALUE.VALUE, "foo").Returning(KEY_VALUE.ID).Fetch(d, db)
+	assert.NoError(t, err)
+
+	err = row.Scan(&returnedId)
+	assert.NoError(t, err)
+
+	// TODO ideally we need to implement LIMIT for SELECT
+	row, err = sqlc.Select(KEY_VALUE.ID).From(KEY_VALUE).Where(KEY_VALUE.VALUE.Eq("foo")).QueryRow(d, db)
+	assert.NoError(t, err)
+
+	err = row.Scan(&selectedId)
+	assert.NoError(t, err)
+
+	assert.Equal(t, returnedId, selectedId, "Returned id was not the same as the subsequent selected id")
+
 }


### PR DESCRIPTION
As discussed in #5, this patch provides basic support for the RETURNING syntax on Postgres.

Take the following example auto-increment table definition:

``` sql
CREATE TABLE key_value 
(
    id SERIAL PRIMARY KEY,
    value TEXT
);
```

You can use the `Returning()` API like so:

``` go
var id int
row, err := sqlc.InsertInto(KEY_VALUE).
                 SetString(KEY_VALUE.VALUE, "foo").
                 Returning(KEY_VALUE.ID).
                 Fetch(d, db)
err = row.Scan(&id)
```

Right now, no other database is supported, so if people require this, then let their requirements be known. Also, the API only accepts one column definition in the `Returning()` function - in the future we could expand this to be variadic. There are probably are few more things that could be made more flexible as well.
